### PR TITLE
fix: remove lower-casing to return original lightning address

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,7 +70,7 @@ export const isLnurl = (url: string): boolean => {
  */
 export const isLightningAddress = (address: string): boolean => {
   if (!address) return false
-  return LN_ADDRESS_REGEX.test(address.toLowerCase())
+  return LN_ADDRESS_REGEX.test(address)
 }
 
 /**
@@ -83,7 +83,7 @@ export const parseLightningAddress = (
   address: string
 ): LightningAddress | null => {
   if (!address) return null
-  const result = LN_ADDRESS_REGEX.exec(address.toLowerCase())
+  const result = LN_ADDRESS_REGEX.exec(address)
   return result ? { username: result[1], domain: result[2] } : null
 }
 


### PR DESCRIPTION
## Description

We came across an instance where the lightning addresses for `escola.naobanco.com` domain are case-sensitive and would fail when parsed through this library (see https://github.com/GaloyMoney/galoy-client/issues/141).